### PR TITLE
Add Mirror-based FPS player prefab and network manager

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,0 +1,332 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
+  - component: {fileID: 6}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8}
+  - {fileID: 12}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!143 &3
+CharacterController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Height: 1.8
+  m_Radius: 0.3
+  m_SlopeLimit: 45
+  m_StepOffset: 0.3
+  m_SkinWidth: 0.02
+  m_MinMoveDistance: 0
+  m_Center: {x: 0, y: 0.9, z: 0}
+--- !u!114 &4
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  sceneId: 0
+  _assetId: 0
+  serverOnly: 0
+  visibility: 0
+  hasSpawned: 0
+--- !u!114 &5
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ff3ba0becae47b8b9381191598957c8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  syncMethod: 0
+  syncDirection: 1
+  syncMode: 0
+  syncInterval: 0.05
+  updateMethod: 0
+  target: {fileID: 2}
+  syncPosition: 1
+  syncRotation: 1
+  syncScale: 0
+  onlySyncOnChange: 1
+  compressRotation: 1
+  interpolatePosition: 1
+  interpolateRotation: 1
+  interpolateScale: 1
+  coordinateSpace: 0
+  timelineOffset: 1
+  showGizmos: 0
+  showOverlay: 0
+--- !u!114 &6
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3fb924c749414899b28efd34e278d3b9, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  controller: {fileID: 3}
+  camRoot: {fileID: 12}
+  cam: {fileID: 15}
+  audioListener: {fileID: 16}
+  walkSpeed: 6
+  sprintSpeed: 9
+  jumpHeight: 1.4
+  gravity: -9.81
+  mouseSensitivity: 120
+  minPitch: -80
+  maxPitch: 80
+  lockCursor: 1
+--- !u!1 &7
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8}
+  - component: {fileID: 9}
+  - component: {fileID: 10}
+  m_Layer: 0
+  m_Name: Visual
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &9
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &10
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 4294967295
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &11
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 12}
+  m_Layer: 0
+  m_Name: CamRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &12
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.6, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 14}
+  m_Father: {fileID: 2}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &13
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 14}
+  - component: {fileID: 15}
+  - component: {fileID: 16}
+  m_Layer: 0
+  m_Name: Cam
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &14
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 13}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 12}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &15
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 13}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &16
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 13}
+  m_Enabled: 0

--- a/Assets/Prefabs/Player.prefab.meta
+++ b/Assets/Prefabs/Player.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ea17c01b693a46c4b0c1361eff003901
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Runtime/Scripts/Network/MyNetworkManager.cs
+++ b/Assets/_Runtime/Scripts/Network/MyNetworkManager.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Mirror;
+using UnityEngine;
+
+public class MyNetworkManager : NetworkManager
+{
+    // Se quiser forçar aleatório mesmo sem configurar no inspector
+    [Header("Spawn")]
+    public bool forceRandomSpawn = true;
+
+    public override void OnServerAddPlayer(NetworkConnectionToClient conn)
+    {
+        Transform startPos = null;
+
+        if (forceRandomSpawn)
+        {
+            // 'startPositions' é mantida pela classe base a partir dos componentes NetworkStartPosition na cena
+            if (startPositions != null && startPositions.Count > 0)
+            {
+                int index = Random.Range(0, startPositions.Count);
+                startPos = startPositions[index];
+            }
+        }
+        else
+        {
+            // comportamento padrão (pode ser RoundRobin/Random dependendo do inspector da classe base)
+            startPos = GetStartPosition();
+        }
+
+        GameObject player = startPos != null
+            ? Instantiate(playerPrefab, startPos.position, startPos.rotation)
+            : Instantiate(playerPrefab);
+
+        NetworkServer.AddPlayerForConnection(conn, player);
+    }
+}

--- a/Assets/_Runtime/Scripts/Network/MyNetworkManager.cs.meta
+++ b/Assets/_Runtime/Scripts/Network/MyNetworkManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c8972f5fb004b09927bbf88cb8ffc3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Runtime/Scripts/Player/PlayerFPS.cs
+++ b/Assets/_Runtime/Scripts/Player/PlayerFPS.cs
@@ -1,0 +1,121 @@
+using Mirror;
+using UnityEngine;
+
+[RequireComponent(typeof(CharacterController))]
+public class PlayerFPS : NetworkBehaviour
+{
+    [Header("Referências")]
+    public CharacterController controller;
+    public Transform camRoot;        // objeto que gira no eixo X (pitch)
+    public Camera cam;               // Camera filha (desabilitada no prefab)
+    public AudioListener audioListener; // Desabilitado no prefab
+
+    [Header("Movimento")]
+    [Tooltip("Velocidade andando (m/s)")]
+    public float walkSpeed = 6f;
+    [Tooltip("Velocidade correndo (m/s)")]
+    public float sprintSpeed = 9f;
+    public float jumpHeight = 1.4f;
+    public float gravity = -9.81f;   // Use valor negativo
+
+    [Header("Câmera")]
+    public float mouseSensitivity = 120f;
+    public float minPitch = -80f;
+    public float maxPitch = 80f;
+    public bool lockCursor = true;
+
+    // estado interno
+    float pitch;       // rotação X da câmera
+    float yaw;         // rotação Y do corpo
+    float yVelocity;   // velocidade vertical (gravidade/pulo)
+
+    void Reset()
+    {
+        controller = GetComponent<CharacterController>();
+        if (transform.Find("CamRoot") != null)
+        {
+            camRoot = transform.Find("CamRoot");
+            var camT = camRoot.Find("Cam");
+            if (camT != null) cam = camT.GetComponent<Camera>();
+            if (camT != null) audioListener = camT.GetComponent<AudioListener>();
+        }
+    }
+
+    public override void OnStartLocalPlayer()
+    {
+        // Ativa câmera e áudio só no dono
+        if (cam != null) cam.enabled = true;
+        if (audioListener != null) audioListener.enabled = true;
+
+        // Cursor travado para FPS
+        if (lockCursor)
+        {
+            Cursor.lockState = CursorLockMode.Locked;
+            Cursor.visible = false;
+        }
+
+        // inicia yaw a partir da rotação atual
+        yaw = transform.eulerAngles.y;
+    }
+
+    void OnDisable()
+    {
+        if (isLocalPlayer && lockCursor)
+        {
+            Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
+        }
+    }
+
+    void Update()
+    {
+        // Apenas o dono processa entrada e move.
+        if (!isLocalPlayer) return;
+
+        Look();
+        Move();
+    }
+
+    void Look()
+    {
+        // Usando Input Manager antigo (Axes padrão do Unity).
+        float mouseX = Input.GetAxis("Mouse X") * mouseSensitivity * Time.deltaTime;
+        float mouseY = Input.GetAxis("Mouse Y") * mouseSensitivity * Time.deltaTime;
+
+        yaw   += mouseX;
+        pitch -= mouseY;
+        pitch = Mathf.Clamp(pitch, minPitch, maxPitch);
+
+        // gira o corpo no Y
+        transform.rotation = Quaternion.Euler(0f, yaw, 0f);
+        // gira a câmera no X (pitch)
+        if (camRoot != null)
+            camRoot.localRotation = Quaternion.Euler(pitch, 0f, 0f);
+    }
+
+    void Move()
+    {
+        float h = Input.GetAxisRaw("Horizontal"); // A/D
+        float v = Input.GetAxisRaw("Vertical");   // W/S
+        bool isSprinting = Input.GetKey(KeyCode.LeftShift);
+
+        Vector3 inputDir = (transform.right * h + transform.forward * v);
+        if (inputDir.sqrMagnitude > 1f) inputDir.Normalize();
+
+        float speed = isSprinting ? sprintSpeed : walkSpeed;
+
+        // Gravidade e pulo
+        if (controller.isGrounded && yVelocity < 0f)
+            yVelocity = -2f; // "cola" no chão
+
+        if (controller.isGrounded && Input.GetButtonDown("Jump"))
+            yVelocity = Mathf.Sqrt(jumpHeight * -2f * gravity);
+
+        yVelocity += gravity * Time.deltaTime;
+
+        Vector3 velocity = inputDir * speed;
+        velocity.y = yVelocity;
+
+        controller.Move(velocity * Time.deltaTime);
+    }
+}

--- a/Assets/_Runtime/Scripts/Player/PlayerFPS.cs.meta
+++ b/Assets/_Runtime/Scripts/Player/PlayerFPS.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3fb924c749414899b28efd34e278d3b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add PlayerFPS component for first-person movement and owner-only input
- create MyNetworkManager to spawn players at random NetworkStartPositions
- include Player prefab with CharacterController, Mirror components, and disabled camera/audio

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d4de8e20833289fa9a3a9e479a94