### PR TITLE
Add interactable interface with player interactor and battery item

### DIFF
--- a/Assets/_Runtime/Scripts/Interaction/IInteractable.cs
+++ b/Assets/_Runtime/Scripts/Interaction/IInteractable.cs
@@ -1,0 +1,14 @@
+using Mirror;
+using UnityEngine;
+
+public interface IInteractable
+{
+    // Pode aplicar gating adicional (ex.: chave, cooldown, etc.)
+    bool CanInteract(NetworkIdentity interactor);
+
+    // Executa a interação no SERVIDOR.
+    void ServerInteract(NetworkIdentity interactor);
+
+    // (Opcional) texto de UI
+    string GetPrompt();
+}

--- a/Assets/_Runtime/Scripts/Interaction/IInteractable.cs.meta
+++ b/Assets/_Runtime/Scripts/Interaction/IInteractable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e30e7b980d9a4a299ccf03fcaff839e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Runtime/Scripts/Interaction/Interactables/Battery.cs
+++ b/Assets/_Runtime/Scripts/Interaction/Interactables/Battery.cs
@@ -1,0 +1,46 @@
+using Mirror;
+using UnityEngine;
+
+[RequireComponent(typeof(NetworkIdentity))]
+public class Battery : NetworkBehaviour, IInteractable
+{
+    [Header("Feedback")]
+    [Tooltip("Mensagem do log no cliente do interator.")]
+    public string pickedMessage = "Battery picked.";
+
+    [Tooltip("Raio máximo que permitimos pegar (m). Deve casar com o PlayerInteractor.")]
+    public float maxServerDistance = 3.2f;
+
+    public bool CanInteract(NetworkIdentity interactor)
+    {
+        if (!isServer) return true; // validação final fica em ServerInteract
+        if (!interactor) return false;
+
+        float dist = Vector3.Distance(interactor.transform.position, transform.position);
+        return dist <= maxServerDistance;
+    }
+
+    public void ServerInteract(NetworkIdentity interactor)
+    {
+        if (!isServer || !interactor) return;
+
+        // Segurança extra de distância
+        if (Vector3.Distance(interactor.transform.position, transform.position) > maxServerDistance)
+            return;
+
+        // TargetRpc: mensagem no cliente que interagiu
+        var conn = interactor.connectionToClient;
+        if (conn != null) TargetOnPicked(conn, pickedMessage);
+
+        // Destrói a bateria no servidor (replica para todos)
+        NetworkServer.Destroy(gameObject);
+    }
+
+    public string GetPrompt() => "Pick up Battery [E]";
+
+    [TargetRpc]
+    void TargetOnPicked(NetworkConnectionToClient target, string msg)
+    {
+        Debug.Log(msg);
+    }
+}

--- a/Assets/_Runtime/Scripts/Interaction/Interactables/Battery.cs.meta
+++ b/Assets/_Runtime/Scripts/Interaction/Interactables/Battery.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9bfea8fadaa544f58ab30db64829ec5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Runtime/Scripts/Interaction/PlayerInteractor.cs
+++ b/Assets/_Runtime/Scripts/Interaction/PlayerInteractor.cs
@@ -1,0 +1,124 @@
+using Mirror;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+[DisallowMultipleComponent]
+public class PlayerInteractor : NetworkBehaviour
+{
+    [Header("Refs")]
+    [Tooltip("Câmera do jogador (usada para raycast de interação).")]
+    public Camera cam;
+    [Tooltip("Raiz de rotação vertical (pitch) do jogador, se houver.")]
+    public Transform camRoot;
+
+    [Header("Interação")]
+    [Tooltip("Distância máxima de interação (m).")]
+    public float interactRange = 3.0f;
+    [Tooltip("Ângulo máximo entre o forward da câmera e o alvo (graus).")]
+    public float maxAimAngle = 8f;
+    [Tooltip("Camadas a IGNORAR (ex.: Player, Ghost). Se vazio, preenche automático.")]
+    public LayerMask ignoreLayers;
+
+    // Novo Input System (reutiliza o wrapper já usado no PlayerFPS)
+    InputSystem_Actions actions;
+    InputAction interactAction;
+
+    // Cache de máscara efetiva para raycast (inverso das ignoradas)
+    int raycastMask;
+
+    void Reset()
+    {
+        if (!cam) cam = GetComponentInChildren<Camera>(true);
+        if (!camRoot && transform.Find("CamRoot")) camRoot = transform.Find("CamRoot");
+    }
+
+    void Awake()
+    {
+        actions = new InputSystem_Actions();
+        interactAction = actions.Player.Interact; // Adicione a action "Interact" no mapa Player
+
+        if (ignoreLayers == 0)
+        {
+            int ig = 0;
+            ig |= LayerMask.NameToLayer("Player") >= 0 ? (1 << LayerMask.NameToLayer("Player")) : 0;
+            ig |= LayerMask.NameToLayer("Ghost")  >= 0 ? (1 << LayerMask.NameToLayer("Ghost"))  : 0;
+            ignoreLayers = ig;
+        }
+        raycastMask = ~ignoreLayers;
+    }
+
+    public override void OnStartLocalPlayer()
+    {
+        actions.Player.Enable();
+        interactAction.performed += OnInteractPerformed;
+
+        if (!cam) cam = GetComponentInChildren<Camera>(true);
+        if (!camRoot && transform.Find("CamRoot")) camRoot = transform.Find("CamRoot");
+    }
+
+    void OnDisable()
+    {
+        if (isLocalPlayer)
+        {
+            actions?.Player.Disable();
+            interactAction.performed -= OnInteractPerformed;
+        }
+    }
+
+    void OnInteractPerformed(InputAction.CallbackContext _)
+    {
+        if (!isLocalPlayer || !cam) return;
+
+        // Raycast do centro da câmera
+        Vector3 origin = cam.transform.position;
+        Vector3 dir    = cam.transform.forward;
+
+        if (Physics.Raycast(origin, dir, out RaycastHit hit, interactRange, raycastMask, QueryTriggerInteraction.Ignore))
+        {
+            // Garante que estamos realmente "olhando" (cone estreito)
+            float angle = Vector3.Angle(dir, (hit.point - origin));
+            if (angle > maxAimAngle) return;
+
+            var ni = hit.collider.GetComponentInParent<NetworkIdentity>();
+            if (!ni) return;
+
+            // Verifica se o objeto implementa IInteractable
+            var interactable = ni.GetComponent<IInteractable>();
+            if (interactable == null) return;
+
+            // Envia pedido ao servidor
+            CmdTryInteract(ni);
+        }
+    }
+
+    [Command]
+    void CmdTryInteract(NetworkIdentity targetNi)
+    {
+        if (!targetNi) return;
+
+        // Validações básicas no servidor (anti-lag/anti-cheat leve)
+        Transform head = camRoot ? camRoot : transform;
+        Vector3 origin = head.position;
+        Vector3 toTarget = targetNi.transform.position - origin;
+
+        if (toTarget.sqrMagnitude > (interactRange * interactRange) + 0.01f) return;
+
+        // LOS simples no servidor (ignora Player/Ghost)
+        int mask = ~ignoreLayers.value;
+        if (Physics.Raycast(origin, toTarget.normalized, out RaycastHit hit, interactRange, mask, QueryTriggerInteraction.Ignore))
+        {
+            var hitNi = hit.collider.GetComponentInParent<NetworkIdentity>();
+            if (hitNi != targetNi) return;
+        }
+        else return;
+
+        var interactable = targetNi.GetComponent<IInteractable>();
+        if (interactable == null) return;
+
+        // Checagem de permissão
+        if (!interactable.CanInteract(netIdentity)) return;
+
+        // Executa no servidor
+        interactable.ServerInteract(netIdentity);
+    }
+}

--- a/Assets/_Runtime/Scripts/Interaction/PlayerInteractor.cs.meta
+++ b/Assets/_Runtime/Scripts/Interaction/PlayerInteractor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30ac92e363264a0e918b391b74d07b8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add `IInteractable` interface defining server-side interaction API
- implement `PlayerInteractor` to raycast and validate server-side interactions
- create `Battery` interactable that logs pickup and is destroyed on server

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fa6157b883329e9edcaee4560d9b