### PR TITLE
Add UV flashlight system and interactable tagging

### DIFF
--- a/Assets/InputSystem_Actions.cs
+++ b/Assets/InputSystem_Actions.cs
@@ -172,6 +172,24 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Flashlight"",
+                    ""type"": ""Button"",
+                    ""id"": ""5e4c387b-83e2-4c4e-9bf1-10dd86730910"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""HoldUV"",
+                    ""type"": ""Button"",
+                    ""id"": ""d4c0a735-8efd-4f12-9e5c-c6a7ac5e1b75"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -557,6 +575,50 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""groups"": ""Keyboard&Mouse"",
                     ""action"": ""Crouch"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""fca7e3f8-3adc-4ddd-bf13-8ac6a77ca469"",
+                    ""path"": ""<Keyboard>/f"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": "";Keyboard&Mouse"",
+                    ""action"": ""Flashlight"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""3218a5ce-6c46-4fe0-971a-eafffa689b4c"",
+                    ""path"": ""<Gamepad>/dpad/up"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": "";Gamepad"",
+                    ""action"": ""Flashlight"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""7791ae4b-523d-4288-8cef-9da776995639"",
+                    ""path"": ""<Keyboard>/q"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": "";Keyboard&Mouse"",
+                    ""action"": ""HoldUV"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""04f10f02-60e7-40eb-91fd-01e591c78c87"",
+                    ""path"": ""<Gamepad>/leftShoulder"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": "";Gamepad"",
+                    ""action"": ""HoldUV"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 }
@@ -1153,6 +1215,8 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
         m_Player_Previous = m_Player.FindAction("Previous", throwIfNotFound: true);
         m_Player_Next = m_Player.FindAction("Next", throwIfNotFound: true);
         m_Player_Sprint = m_Player.FindAction("Sprint", throwIfNotFound: true);
+        m_Player_Flashlight = m_Player.FindAction("Flashlight", throwIfNotFound: true);
+        m_Player_HoldUV = m_Player.FindAction("HoldUV", throwIfNotFound: true);
         // UI
         m_UI = asset.FindActionMap("UI", throwIfNotFound: true);
         m_UI_Navigate = m_UI.FindAction("Navigate", throwIfNotFound: true);
@@ -1255,6 +1319,8 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
     private readonly InputAction m_Player_Previous;
     private readonly InputAction m_Player_Next;
     private readonly InputAction m_Player_Sprint;
+    private readonly InputAction m_Player_Flashlight;
+    private readonly InputAction m_Player_HoldUV;
     /// <summary>
     /// Provides access to input actions defined in input action map "Player".
     /// </summary>
@@ -1302,6 +1368,14 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "Player/Sprint".
         /// </summary>
         public InputAction @Sprint => m_Wrapper.m_Player_Sprint;
+        /// <summary>
+        /// Provides access to the underlying input action "Player/Flashlight".
+        /// </summary>
+        public InputAction @Flashlight => m_Wrapper.m_Player_Flashlight;
+        /// <summary>
+        /// Provides access to the underlying input action "Player/HoldUV".
+        /// </summary>
+        public InputAction @HoldUV => m_Wrapper.m_Player_HoldUV;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -1355,6 +1429,12 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
             @Sprint.started += instance.OnSprint;
             @Sprint.performed += instance.OnSprint;
             @Sprint.canceled += instance.OnSprint;
+            @Flashlight.started += instance.OnFlashlight;
+            @Flashlight.performed += instance.OnFlashlight;
+            @Flashlight.canceled += instance.OnFlashlight;
+            @HoldUV.started += instance.OnHoldUV;
+            @HoldUV.performed += instance.OnHoldUV;
+            @HoldUV.canceled += instance.OnHoldUV;
         }
 
         /// <summary>
@@ -1393,6 +1473,12 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
             @Sprint.started -= instance.OnSprint;
             @Sprint.performed -= instance.OnSprint;
             @Sprint.canceled -= instance.OnSprint;
+            @Flashlight.started -= instance.OnFlashlight;
+            @Flashlight.performed -= instance.OnFlashlight;
+            @Flashlight.canceled -= instance.OnFlashlight;
+            @HoldUV.started -= instance.OnHoldUV;
+            @HoldUV.performed -= instance.OnHoldUV;
+            @HoldUV.canceled -= instance.OnHoldUV;
         }
 
         /// <summary>
@@ -1756,6 +1842,20 @@ public partial class @InputSystem_Actions: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnSprint(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Flashlight" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnFlashlight(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "HoldUV" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnHoldUV(InputAction.CallbackContext context);
     }
     /// <summary>
     /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "UI" which allows adding and removing callbacks.

--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -85,6 +85,24 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "Flashlight",
+                    "type": "Button",
+                    "id": "5e4c387b-83e2-4c4e-9bf1-10dd86730910",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "HoldUV",
+                    "type": "Button",
+                    "id": "d4c0a735-8efd-4f12-9e5c-c6a7ac5e1b75",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -470,6 +488,50 @@
                     "processors": "",
                     "groups": "Keyboard&Mouse",
                     "action": "Crouch",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "fca7e3f8-3adc-4ddd-bf13-8ac6a77ca469",
+                    "path": "<Keyboard>/f",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Flashlight",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "3218a5ce-6c46-4fe0-971a-eafffa689b4c",
+                    "path": "<Gamepad>/dpad/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Flashlight",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "7791ae4b-523d-4288-8cef-9da776995639",
+                    "path": "<Keyboard>/q",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "HoldUV",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "04f10f02-60e7-40eb-91fd-01e591c78c87",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "HoldUV",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/_Runtime/Scripts/Interaction/Interactables/BatteryPickupUV.cs
+++ b/Assets/_Runtime/Scripts/Interaction/Interactables/BatteryPickupUV.cs
@@ -1,0 +1,53 @@
+using Mirror;
+using UnityEngine;
+
+[RequireComponent(typeof(NetworkIdentity))]
+public class BatteryPickupUV : NetworkBehaviour, IInteractable
+{
+    [Header("Mensagens")]
+    public string pickedMsg = "Battery picked.";
+    public string fullMsg   = "UV battery already full.";
+
+    [Header("Validação")]
+    public float maxServerDistance = 3.2f; // opcional extra
+
+    public bool CanInteract(NetworkIdentity interactor)
+    {
+        // Checagem leve; validação final em ServerInteract
+        return interactor != null;
+    }
+
+    public void ServerInteract(NetworkIdentity interactor)
+    {
+        if (!isServer || interactor == null) return;
+
+        // Segurança de distância
+        if (Vector3.Distance(interactor.transform.position, transform.position) > maxServerDistance)
+            return;
+
+        var lights = interactor.GetComponent<PlayerFlashlight>();
+        if (lights == null) return;
+
+        bool added = lights.ServerTryAddUVCharge();
+        var conn   = interactor.connectionToClient;
+
+        if (added)
+        {
+            if (conn != null) TargetNotify(conn, pickedMsg);
+            NetworkServer.Destroy(gameObject); // some para todos
+        }
+        else
+        {
+            if (conn != null) TargetNotify(conn, fullMsg);
+            // NÃO destrói se estiver cheio
+        }
+    }
+
+    public string GetPrompt() => "Pick up Battery [E]";
+
+    [TargetRpc]
+    void TargetNotify(NetworkConnectionToClient target, string msg)
+    {
+        Debug.Log(msg);
+    }
+}

--- a/Assets/_Runtime/Scripts/Interaction/PlayerInteractor.cs
+++ b/Assets/_Runtime/Scripts/Interaction/PlayerInteractor.cs
@@ -26,6 +26,8 @@ public class PlayerInteractor : NetworkBehaviour
     // Cache de máscara efetiva para raycast (inverso das ignoradas)
     int raycastMask;
 
+    public const string InteractableTag = "Interactable";
+
     void Reset()
     {
         if (!cam) cam = GetComponentInChildren<Camera>(true);
@@ -79,6 +81,12 @@ public class PlayerInteractor : NetworkBehaviour
             float angle = Vector3.Angle(dir, (hit.point - origin));
             if (angle > maxAimAngle) return;
 
+            if (!hit.collider.CompareTag(InteractableTag))
+            {
+                Debug.Log($"Hit {hit.collider.name} without tag {InteractableTag}");
+                return;
+            }
+
             var ni = hit.collider.GetComponentInParent<NetworkIdentity>();
             if (!ni) return;
 
@@ -86,6 +94,7 @@ public class PlayerInteractor : NetworkBehaviour
             var interactable = ni.GetComponent<IInteractable>();
             if (interactable == null) return;
 
+            Debug.Log($"Attempting interaction with {ni.name}");
             // Envia pedido ao servidor
             CmdTryInteract(ni);
         }
@@ -95,6 +104,8 @@ public class PlayerInteractor : NetworkBehaviour
     void CmdTryInteract(NetworkIdentity targetNi)
     {
         if (!targetNi) return;
+
+        Debug.Log($"Server processing interaction with {targetNi.name}");
 
         // Validações básicas no servidor (anti-lag/anti-cheat leve)
         Transform head = camRoot ? camRoot : transform;

--- a/Assets/_Runtime/Scripts/Player/PlayerFlashlight.cs
+++ b/Assets/_Runtime/Scripts/Player/PlayerFlashlight.cs
@@ -1,0 +1,219 @@
+using Mirror;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using System.Collections;
+
+[DisallowMultipleComponent]
+public class PlayerFlashlight : NetworkBehaviour
+{
+    [Header("Refs")]
+    [Tooltip("GameObject da luz normal (ex.: um filho com Light/SpotLight).")]
+    public GameObject normalLightGO;
+    [Tooltip("GameObject da luz UV (pode ser outro Light com cor roxa, layer/culling específico).")]
+    public GameObject uvLightGO;
+
+    [Header("UV Config")]
+    [Tooltip("Cargas máximas da UV.")]
+    public int maxCharges = 3;
+    [Tooltip("Duração (s) de cada carga da UV.")]
+    public float secondsPerCharge = 12f;
+
+    // ===== Estado replicado =====
+    [SyncVar(hook = nameof(OnNormalChanged))] private bool normalOn;
+    [SyncVar(hook = nameof(OnUVChanged))] private bool uvOn;
+    [SyncVar(hook = nameof(OnUVSecondsChanged))] private float uvSecondsRemaining; // 0 .. maxCharges*secondsPerCharge
+
+    // ===== Input (somente no cliente local) =====
+    private InputSystem_Actions actions;
+    private InputAction flashlightAction; // toggle normal
+    private InputAction holdUVAction;     // hold UV
+
+    // ===== Server runtime =====
+    private Coroutine drainCo;
+
+    // ===== Helpers =====
+    private float MaxUVSeconds => maxCharges * secondsPerCharge;
+
+    void Reset()
+    {
+        // Tenta achar automaticamente luzes por nome
+        if (!normalLightGO && transform.Find("Light_Normal"))
+            normalLightGO = transform.Find("Light_Normal").gameObject;
+        if (!uvLightGO && transform.Find("Light_UV"))
+            uvLightGO = transform.Find("Light_UV").gameObject;
+    }
+
+    void Awake()
+    {
+        // Garante estado visual consistente mesmo antes do primeiro hook
+        ApplyNormalVisual(normalOn);
+        ApplyUVVisual(uvOn);
+    }
+
+    public override void OnStartServer()
+    {
+        // Estado inicial
+        uvSecondsRemaining = Mathf.Clamp(uvSecondsRemaining, 0f, MaxUVSeconds);
+        normalOn = false;
+        uvOn = false;
+    }
+
+    public override void OnStartLocalPlayer()
+    {
+        actions = new InputSystem_Actions();
+        actions.Player.Enable();
+
+        flashlightAction = actions.Player.Flashlight; // Button (toggle)
+        holdUVAction     = actions.Player.HoldUV;     // Button (press/hold)
+
+        flashlightAction.performed += OnFlashlightTogglePerformed;
+        holdUVAction.performed     += OnHoldUVPressed;
+        holdUVAction.canceled      += OnHoldUVReleased;
+
+        // Garante que o visual local reflete o estado inicial replicado
+        ApplyNormalVisual(normalOn);
+        ApplyUVVisual(uvOn);
+    }
+
+    void OnDisable()
+    {
+        if (isLocalPlayer && actions != null)
+        {
+            flashlightAction.performed -= OnFlashlightTogglePerformed;
+            holdUVAction.performed     -= OnHoldUVPressed;
+            holdUVAction.canceled      -= OnHoldUVReleased;
+            actions.Player.Disable();
+        }
+    }
+
+    // ===== INPUT callbacks (cliente local) =====
+
+    void OnFlashlightTogglePerformed(InputAction.CallbackContext _)
+    {
+        if (!isLocalPlayer) return;
+        CmdSetNormal(!normalOn);
+    }
+
+    void OnHoldUVPressed(InputAction.CallbackContext _)
+    {
+        if (!isLocalPlayer) return;
+        CmdRequestUV(true);
+    }
+
+    void OnHoldUVReleased(InputAction.CallbackContext _)
+    {
+        if (!isLocalPlayer) return;
+        CmdRequestUV(false);
+    }
+
+    // ===== Commands =====
+
+    [Command]
+    void CmdSetNormal(bool turnOn)
+    {
+        // Sem restrição de recurso
+        normalOn = turnOn;
+    }
+
+    [Command]
+    void CmdRequestUV(bool wantOn)
+    {
+        if (wantOn)
+        {
+            // Liga se houver recurso
+            if (!uvOn && uvSecondsRemaining > 0f)
+            {
+                uvOn = true;
+                StartDrainIfNeeded();
+            }
+        }
+        else
+        {
+            // Desliga sob comando do cliente (soltou o botão)
+            if (uvOn)
+            {
+                uvOn = false;
+                StopDrainIfNeeded();
+            }
+        }
+    }
+
+    // ===== Consumo da UV (servidor) =====
+
+    void StartDrainIfNeeded()
+    {
+        if (!isServer) return;
+        if (drainCo == null && uvOn && uvSecondsRemaining > 0f)
+            drainCo = StartCoroutine(ServerDrainLoop());
+    }
+
+    void StopDrainIfNeeded()
+    {
+        if (!isServer) return;
+        if (drainCo != null)
+        {
+            StopCoroutine(drainCo);
+            drainCo = null;
+        }
+    }
+
+    IEnumerator ServerDrainLoop()
+    {
+        // Consome tempo enquanto UV estiver ligada e houver tempo
+        while (uvOn && uvSecondsRemaining > 0f)
+        {
+            uvSecondsRemaining -= Time.deltaTime;
+            if (uvSecondsRemaining <= 0f)
+            {
+                uvSecondsRemaining = 0f;
+                uvOn = false; // Auto-off quando acabar
+                break;
+            }
+            yield return null;
+        }
+        drainCo = null;
+    }
+
+    // ===== API do servidor para receber baterias =====
+
+    /// <summary> Adiciona +1 carga (12s). Retorna true se adicionou; false se já estava no máximo. </summary>
+    [Server]
+    public bool ServerTryAddUVCharge()
+    {
+        if (uvSecondsRemaining >= MaxUVSeconds - 0.001f)
+            return false;
+
+        uvSecondsRemaining = Mathf.Min(uvSecondsRemaining + secondsPerCharge, MaxUVSeconds);
+        return true;
+    }
+
+    // ===== Hooks de SyncVar =====
+
+    void OnNormalChanged(bool _, bool newVal) => ApplyNormalVisual(newVal);
+    void OnUVChanged(bool _, bool newVal) => ApplyUVVisual(newVal);
+    void OnUVSecondsChanged(float _, float __)
+    {
+        // Ponto para UI/HUD: atualizar barra/ícone se desejar.
+        // Ex.: dispatch de evento, UnityEvent, etc.
+    }
+
+    // ===== Visual local (todos os clientes) =====
+
+    void ApplyNormalVisual(bool on)
+    {
+        if (normalLightGO) normalLightGO.SetActive(on);
+    }
+
+    void ApplyUVVisual(bool on)
+    {
+        if (uvLightGO) uvLightGO.SetActive(on);
+    }
+
+    // ===== Utilidades públicas (cliente) =====
+
+    /// <summary> Retorna [0..1] de reserva relativa (para UI). </summary>
+    public float GetUVFill01() => MaxUVSeconds <= 0f ? 0f : Mathf.Clamp01(uvSecondsRemaining / MaxUVSeconds);
+
+    /// <summary> Retorna cargas inteiras aproximadas (para exibir ícones). </summary>
+    public int GetUVCharges() => Mathf.CeilToInt(uvSecondsRemaining / Mathf.Max(0.001f, secondsPerCharge));
+}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Interactable
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## Summary
- Implement UV flashlight controller with normal and UV lights, server-side UV drain, and input actions
- Add battery pickup that restores UV charges
- Tag interactables and add debug logs to PlayerInteractor; extend input mappings and tag list

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*


------
https://chatgpt.com/codex/tasks/task_e_68a7fbc224fc8332815525eba8ec765d