### PR TITLE
Add server-validated interaction system

### DIFF
--- a/Assets/_Runtime/Scripts/Interaction/IInteractable.cs
+++ b/Assets/_Runtime/Scripts/Interaction/IInteractable.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Game.Interaction
+{
+    /// <summary>
+    /// Contrato que qualquer objeto interagível deve cumprir.
+    /// A execução de ServerInteract SEMPRE ocorre no servidor.
+    /// </summary>
+    public interface IInteractable
+    {
+        string GetInteractText();               // opcional: texto para UI ("Abrir", "Pegar", etc.)
+        bool CanInteract(GameObject interactor); // validação extra de permissão/estado
+        void ServerInteract(GameObject interactor); // lógica final da interação (no servidor)
+    }
+}

--- a/Assets/_Runtime/Scripts/Interaction/IInteractable.cs.meta
+++ b/Assets/_Runtime/Scripts/Interaction/IInteractable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 57f7ffaec78d419cb5e1422f347a76f4

--- a/Assets/_Runtime/Scripts/Interaction/Interactables/TestInteractable.cs
+++ b/Assets/_Runtime/Scripts/Interaction/Interactables/TestInteractable.cs
@@ -1,0 +1,32 @@
+using Mirror;
+using UnityEngine;
+using Game.Interaction;
+
+[RequireComponent(typeof(NetworkIdentity))]
+[DisallowMultipleComponent]
+public class TestInteractable : NetworkBehaviour, IInteractable
+{
+    [SerializeField] private string displayName = "Alavanca de Teste";
+
+    public string GetInteractText() => $"Interagir ({displayName})";
+    public bool CanInteract(GameObject interactor) => true;
+
+    [Server]
+    public void ServerInteract(GameObject interactor)
+    {
+        var ni = interactor.GetComponent<NetworkIdentity>();
+        Debug.Log($"[SERVER] {interactor.name} (netId {ni?.netId}) interagiu com {name}");
+
+        // Feedback só para o cliente que interagiu (exemplo simples)
+        if (ni != null && ni.connectionToClient != null)
+        {
+            TargetShowMessage(ni.connectionToClient, $"Você interagiu com: {displayName}");
+        }
+    }
+
+    [TargetRpc]
+    private void TargetShowMessage(NetworkConnectionToClient conn, string msg)
+    {
+        Debug.Log($"[CLIENT] {msg}");
+    }
+}

--- a/Assets/_Runtime/Scripts/Interaction/Interactables/TestInteractable.cs.meta
+++ b/Assets/_Runtime/Scripts/Interaction/Interactables/TestInteractable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 486a917051ca450b983d434814e386c1

--- a/Assets/_Runtime/Scripts/Player/PlayerInteractor.cs
+++ b/Assets/_Runtime/Scripts/Player/PlayerInteractor.cs
@@ -1,0 +1,119 @@
+using Mirror;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using Game.Interaction;
+
+[DisallowMultipleComponent]
+public class PlayerInteractor : NetworkBehaviour, InputSystem_Actions.IPlayerActions
+{
+    [Header("Raycast")]
+    [SerializeField] private Camera playerCamera;
+    [SerializeField] private float interactDistance = 3.0f;
+    [Tooltip("Somente objetos nestas layers serão considerados interagíveis.")]
+    [SerializeField] private LayerMask interactableLayer;
+    [Tooltip("Layers a serem ignoradas (ex.: Player, Ignore Raycast).")]
+    [SerializeField] private LayerMask ignoreLayers;
+
+    private InputSystem_Actions input;
+    private NetworkIdentity currentTarget;
+    private Ray lastRay;
+
+    private void Awake()
+    {
+        if (playerCamera == null && isLocalPlayer)
+            playerCamera = Camera.main;
+    }
+
+    public override void OnStartAuthority()
+    {
+        input = new InputSystem_Actions();
+        input.Player.SetCallbacks(this);
+        input.Player.Enable();
+
+        Cursor.lockState = CursorLockMode.Locked;
+        Cursor.visible = false;
+    }
+
+    public override void OnStopAuthority()
+    {
+        if (input != null)
+        {
+            input.Player.Disable();
+            input.Dispose();
+        }
+    }
+
+    private void Update()
+    {
+        if (!hasAuthority) return;
+
+        var cam = playerCamera != null ? playerCamera : Camera.main;
+        if (cam == null) return;
+
+        lastRay = new Ray(cam.transform.position, cam.transform.forward);
+
+        int maskInclude = ~ignoreLayers.value;
+        if (Physics.Raycast(lastRay, out var hit, interactDistance, maskInclude, QueryTriggerInteraction.Ignore))
+        {
+            bool isOnInteractableLayer = (interactableLayer.value & (1 << hit.collider.gameObject.layer)) != 0;
+            currentTarget = isOnInteractableLayer
+                ? hit.collider.GetComponentInParent<NetworkIdentity>()
+                : null;
+        }
+        else
+        {
+            currentTarget = null;
+        }
+
+        Debug.DrawRay(lastRay.origin, lastRay.direction * interactDistance, currentTarget ? Color.green : Color.red);
+    }
+
+    public void OnInteract(InputAction.CallbackContext ctx)
+    {
+        if (!hasAuthority) return;
+
+        if (ctx.performed && currentTarget != null)
+        {
+            CmdInteract(currentTarget, lastRay.origin, lastRay.direction);
+        }
+    }
+
+    [Command]
+    private void CmdInteract(NetworkIdentity target, Vector3 origin, Vector3 direction)
+    {
+        if (target == null) return;
+
+        int maskInclude = ~ignoreLayers.value;
+        bool valid = false;
+
+        if (Physics.Raycast(origin, direction, out var hit, interactDistance + 0.5f, maskInclude, QueryTriggerInteraction.Ignore))
+        {
+            var hitNI = hit.collider.GetComponentInParent<NetworkIdentity>();
+            valid = (hitNI == target);
+        }
+        else
+        {
+            var dist = Vector3.Distance(origin, target.transform.position);
+            valid = dist <= (interactDistance + 0.5f);
+        }
+
+        if (!valid) return;
+
+        var interactable = target.GetComponent<IInteractable>();
+        if (interactable != null && interactable.CanInteract(gameObject))
+        {
+            interactable.ServerInteract(gameObject);
+        }
+    }
+
+    public void OnMove(InputAction.CallbackContext context) { }
+    public void OnLook(InputAction.CallbackContext context) { }
+    public void OnAttack(InputAction.CallbackContext context) { }
+    public void OnCrouch(InputAction.CallbackContext context) { }
+    public void OnJump(InputAction.CallbackContext context) { }
+    public void OnPrevious(InputAction.CallbackContext context) { }
+    public void OnNext(InputAction.CallbackContext context) { }
+    public void OnSprint(InputAction.CallbackContext context) { }
+    public void OnFlashlight(InputAction.CallbackContext context) { }
+    public void OnHoldUV(InputAction.CallbackContext context) { }
+}

--- a/Assets/_Runtime/Scripts/Player/PlayerInteractor.cs.meta
+++ b/Assets/_Runtime/Scripts/Player/PlayerInteractor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b018bdafc604878a050ab03d04a9b49


### PR DESCRIPTION
## Summary
- define `IInteractable` interface for networked objects
- add sample `TestInteractable` behaviour demonstrating server-authoritative interactions
- implement `PlayerInteractor` to raycast, validate, and invoke interactions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a80f085118833284b210a1aebf7068