### PR TITLE
Add ghost archetype, AI, and spawner

### DIFF
--- a/Assets/_Runtime/Scripts/Enemies/Ghosts.meta
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c770c437cbc4423596a59bef916b6493

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/Ghost.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/Ghost.cs
@@ -1,0 +1,89 @@
+using UnityEngine;
+using UnityEngine.AI;
+using Mirror;
+using System.Collections;
+
+[RequireComponent(typeof(NetworkIdentity))]
+[RequireComponent(typeof(NavMeshAgent))]
+[RequireComponent(typeof(NetworkTransform))]
+public class Ghost : NetworkBehaviour
+{
+    [SerializeField] private GhostArchetype archetype;
+
+    private NavMeshAgent agent;
+
+    public override void OnStartServer()
+    {
+        base.OnStartServer();
+        agent = GetComponent<NavMeshAgent>();
+        ApplyConfig();
+        StartCoroutine(WanderLoop());
+    }
+
+    void ApplyConfig()
+    {
+        if (!agent || archetype == null) return;
+        agent.speed = archetype.moveSpeed;
+        agent.acceleration = archetype.acceleration;
+        agent.angularSpeed = archetype.angularSpeed;
+        agent.stoppingDistance = archetype.stoppingDistance;
+        agent.areaMask = archetype.areaMask;
+        agent.autoRepath = true;
+        agent.obstacleAvoidanceType = ObstacleAvoidanceType.HighQualityObstacleAvoidance;
+    }
+
+    [ServerCallback]
+    private IEnumerator WanderLoop()
+    {
+        var idleRange = archetype ? archetype.idlePauseRange : new Vector2(0.5f, 1.5f);
+        var roamRange = archetype ? archetype.roamIntervalRange : new Vector2(2f, 4f);
+        var radius    = archetype ? archetype.wanderRadius      : 10f;
+        var sampleMax = archetype ? archetype.sampleMaxDistance : 2f;
+
+        while (true)
+        {
+            if (TryGetRandomPointOnNavmesh(transform.position, radius, out var dest, agent.areaMask, sampleMax))
+                agent.SetDestination(dest);
+
+            // Janela de movimento
+            float travelWindow = Random.Range(roamRange.x, roamRange.y);
+            float endTime = Time.time + travelWindow;
+            while (Time.time < endTime)
+            {
+                yield return null;
+                if (!agent.pathPending && agent.remainingDistance <= agent.stoppingDistance + 0.1f) break;
+            }
+
+            // Pausa curta
+            yield return new WaitForSeconds(Random.Range(idleRange.x, idleRange.y));
+        }
+    }
+
+    public static bool TryGetRandomPointOnNavmesh(Vector3 center, float radius, out Vector3 result, int areaMask, float maxSampleDistance)
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            var random = Random.insideUnitSphere * radius;
+            random.y = 0f;
+            var candidate = center + random;
+            if (NavMesh.SamplePosition(candidate, out var hit, maxSampleDistance, areaMask))
+            {
+                result = hit.position;
+                return true;
+            }
+        }
+        result = center;
+        return false;
+    }
+
+    public override void OnStartClient()
+    {
+        base.OnStartClient();
+        // Autoridade de movimento somente no servidor:
+        if (!isServer)
+        {
+            var a = GetComponent<NavMeshAgent>();
+            if (a) a.enabled = false;
+        }
+    }
+}

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/Ghost.cs.meta
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/Ghost.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2f8321e620164fe483c38096777e4309

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "PhantomShift/Ghost Archetype")]
+public class GhostArchetype : ScriptableObject
+{
+    public enum Class { Weak, Possessor, Heavy }
+    public Class ghostClass = Class.Weak;
+
+    [Header("Stats")]
+    public int maxHP = 100;
+    public float moveSpeed = 3.0f;
+    public float acceleration = 8f;
+    public float angularSpeed = 240f;
+    public float stoppingDistance = 0.2f;
+
+    [Header("Wander")]
+    public float wanderRadius = 12f;
+    public float pathRecalcDistance = 0.6f;
+    public Vector2 idlePauseRange = new Vector2(0.5f, 1.5f);
+    public Vector2 roamIntervalRange = new Vector2(2f, 4f);
+
+    [Header("NavMesh")]
+    public int areaMask = ~0; // todas as áreas
+    public float sampleMaxDistance = 2.0f;
+}

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs.meta
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dc87f677572442e38cc355483d080b55

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostSpawner.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostSpawner.cs
@@ -1,0 +1,142 @@
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using Mirror;
+using UnityEngine.AI;
+
+public class GhostSpawner : NetworkBehaviour
+{
+    [System.Serializable]
+    public class Batch
+    {
+        public GameObject ghostPrefab;
+        [Min(1)] public int count = 1;
+    }
+
+    [Header("Plan")]
+    public List<Batch> plan = new List<Batch>();
+
+    [Header("Spawn Points")]
+    public List<Transform> spawnPoints = new List<Transform>();
+    public bool randomizeSpawnPoints = true;
+    public bool avoidImmediateRepeats = true; // percorre todos antes de reshuffle
+
+    [Header("Spawn Options")]
+    public bool spawnOnStart = true;
+    public float delayBetweenSpawns = 0.15f;
+    public float spawnJitterRadius = 0.6f;
+
+    [Header("NavMesh Projection")]
+    public bool clampToNavMesh = true;
+    public float maxProjectionDistance = 2.0f;
+    public int areaMask = ~0;
+
+    [Header("Determinism / Seed (opcional)")]
+    public bool useFixedSeed = false;
+    public int seed = 12345;
+
+    private System.Random prng;
+
+    public override void OnStartServer()
+    {
+        base.OnStartServer();
+        if (useFixedSeed) prng = new System.Random(seed);
+        if (spawnOnStart) StartCoroutine(SpawnAll());
+    }
+
+    [Server]
+    public IEnumerator SpawnAll()
+    {
+        if (spawnPoints == null || spawnPoints.Count == 0)
+        {
+            Debug.LogWarning($"[{nameof(GhostSpawner)}] No spawn points configured.");
+            yield break;
+        }
+
+        var indexOrder = BuildIndexOrder(spawnPoints.Count);
+        int indexPtr = 0;
+
+        foreach (var b in plan)
+        {
+            if (!b.ghostPrefab)
+            {
+                Debug.LogWarning("Ghost prefab missing in plan.");
+                continue;
+            }
+
+            for (int i = 0; i < b.count; i++)
+            {
+                var sp = spawnPoints[indexOrder[indexPtr]];
+                indexPtr = (indexPtr + 1) % indexOrder.Count;
+
+                Vector3 pos = GetSpawnPosition(sp.position);
+                Quaternion rot = sp.rotation;
+
+                GameObject ghost = Instantiate(b.ghostPrefab, pos, rot);
+                NetworkServer.Spawn(ghost);
+
+                if (delayBetweenSpawns > 0)
+                    yield return new WaitForSeconds(delayBetweenSpawns);
+            }
+
+            if (randomizeSpawnPoints && avoidImmediateRepeats)
+            {
+                indexOrder = BuildIndexOrder(spawnPoints.Count);
+                indexPtr = 0;
+            }
+        }
+    }
+
+    private List<int> BuildIndexOrder(int count)
+    {
+        var list = new List<int>(count);
+        for (int i = 0; i < count; i++) list.Add(i);
+
+        if (randomizeSpawnPoints)
+        {
+            if (useFixedSeed)
+            {
+                for (int i = list.Count - 1; i > 0; i--)
+                {
+                    int j = prng.Next(i + 1);
+                    (list[i], list[j]) = (list[j], list[i]);
+                }
+            }
+            else
+            {
+                for (int i = list.Count - 1; i > 0; i--)
+                {
+                    int j = Random.Range(0, i + 1);
+                    (list[i], list[j]) = (list[j], list[i]);
+                }
+            }
+        }
+        return list;
+    }
+
+    private Vector3 GetSpawnPosition(Vector3 basePos)
+    {
+        Vector2 jitter = useFixedSeed
+            ? new Vector2((float)prng.NextDouble() - 0.5f, (float)prng.NextDouble() - 0.5f)
+            : new Vector2(Random.value - 0.5f, Random.value - 0.5f);
+
+        var pos = basePos + new Vector3(jitter.x, 0f, jitter.y) * spawnJitterRadius;
+
+        if (clampToNavMesh && NavMesh.SamplePosition(pos, out var hit, maxProjectionDistance, areaMask))
+            pos = hit.position;
+
+        return pos;
+    }
+
+#if UNITY_EDITOR
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.cyan;
+        foreach (var t in spawnPoints)
+        {
+            if (!t) continue;
+            Gizmos.DrawWireSphere(t.position, 0.3f);
+        }
+    }
+#endif
+}

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostSpawner.cs.meta
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostSpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef65c36d58a3494ea462819bf8331492


### PR DESCRIPTION
## Summary
- add `GhostArchetype` ScriptableObject for tuning stats and wander behavior
- implement server-authoritative `Ghost` with NavMesh wandering
- create `GhostSpawner` to spawn configurable batches across randomized points

## Testing
- `npm test` *(fails: Could not read package.json)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c679437083329862560d1e07c43a