### PR TITLE
Add ghost UV capture system

### DIFF
--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 
 [CreateAssetMenu(menuName = "PhantomShift/Ghost Archetype")]
-public class GhostArchetype : ScriptableObject
+public partial class GhostArchetype : ScriptableObject
 {
     public enum Class { Weak, Possessor, Heavy }
     public Class ghostClass = Class.Weak;
@@ -22,4 +22,14 @@ public class GhostArchetype : ScriptableObject
     [Header("NavMesh")]
     public int areaMask = ~0; // todas as áreas
     public float sampleMaxDistance = 2.0f;
+
+    [Header("Capture (UV/Stun)")]
+    public float capture_uvSecondsToStun = 2.0f;
+    public float capture_stunSeconds = 3.0f;
+    public float capture_exposureGraceWindow = 0.6f;
+    public float capture_fleeDecisionInterval = 0.25f;
+    public Vector2 capture_fleeStepRange = new Vector2(1.5f, 3.5f);
+    public float capture_fleeRadius = 10f;
+    public AnimationCurve capture_escapeCurve = AnimationCurve.EaseInOut(0,0,1,1);
+    public AnimationCurve capture_stunCurve   = AnimationCurve.EaseInOut(0,1,1,0);
 }

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostCaptureable.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostCaptureable.cs
@@ -1,0 +1,178 @@
+using System.Collections;
+using Mirror;
+using UnityEngine;
+using UnityEngine.AI;
+using UnityEngine.Events;
+
+[DisallowMultipleComponent]
+[RequireComponent(typeof(Ghost))]
+[RequireComponent(typeof(NavMeshAgent))]
+public class GhostCaptureable : NetworkBehaviour
+{
+    [SerializeField] private GhostArchetype archetype;
+
+    [Header("Capture (UV/Stun)")]
+    public float uvSecondsToStun = 2.0f;
+    public float stunSeconds = 3.0f;
+    public float exposureGraceWindow = 0.6f;
+    public float fleeDecisionInterval = 0.25f;
+    public Vector2 fleeStepRange = new Vector2(1.5f, 3.5f);
+    public float fleeRadius = 10f;
+    public AnimationCurve escapeCurve = AnimationCurve.EaseInOut(0,0,1,1);
+    public AnimationCurve stunCurve   = AnimationCurve.EaseInOut(0,1,1,0);
+
+    [System.Serializable] public class FloatEvent : UnityEvent<float> {}
+    public UnityEvent onFleeStart;
+    public UnityEvent onFleeEnd;
+    public UnityEvent onStunStart;
+    public UnityEvent onStunEnd;
+    public FloatEvent onEscapeIntensity;
+    public FloatEvent onStunIntensity;
+
+    [SyncVar(hook = nameof(OnFleeState))]  private bool fleeing;
+    [SyncVar(hook = nameof(OnStunState))]  private bool stunned;
+    [SyncVar(hook = nameof(OnEscapeIntensity))] private float escapeIntensity;
+    [SyncVar(hook = nameof(OnStunIntensity))]   private float stunIntensity;
+
+    private Ghost ghost;
+    private NavMeshAgent agent;
+    private Coroutine fleeCo;
+    private Coroutine stunCo;
+    private float exposureTimer;
+    private float lastUVTime;
+    private Vector3 lastOrigin;
+
+    public override void OnStartServer()
+    {
+        ghost = GetComponent<Ghost>();
+        agent = GetComponent<NavMeshAgent>();
+        ApplyConfig();
+    }
+
+    void ApplyConfig()
+    {
+        if (!archetype) return;
+        uvSecondsToStun = archetype.capture_uvSecondsToStun;
+        stunSeconds = archetype.capture_stunSeconds;
+        exposureGraceWindow = archetype.capture_exposureGraceWindow;
+        fleeDecisionInterval = archetype.capture_fleeDecisionInterval;
+        fleeStepRange = archetype.capture_fleeStepRange;
+        fleeRadius = archetype.capture_fleeRadius;
+        escapeCurve = archetype.capture_escapeCurve;
+        stunCurve = archetype.capture_stunCurve;
+    }
+
+    [Server]
+    public void ServerApplyUVHit(Vector3 origin, float dt)
+    {
+        float now = Time.time;
+        if (now - lastUVTime > exposureGraceWindow)
+            exposureTimer = 0f;
+
+        lastUVTime = now;
+        exposureTimer += dt;
+        lastOrigin = origin;
+
+        if (!stunned)
+        {
+            if (exposureTimer >= uvSecondsToStun)
+            {
+                StartStun();
+            }
+            else
+            {
+                StartFlee();
+            }
+        }
+    }
+
+    [ServerCallback]
+    void Update()
+    {
+        if (!stunned && Time.time - lastUVTime > exposureGraceWindow)
+        {
+            exposureTimer = 0f;
+            StopFlee();
+        }
+    }
+
+    [Server]
+    void StartFlee()
+    {
+        if (fleeing || stunned) return;
+        fleeing = true;
+        ghost.ServerSetExternalControl(true);
+        fleeCo = StartCoroutine(FleeLoop());
+    }
+
+    [Server]
+    void StopFlee()
+    {
+        if (!fleeing) return;
+        fleeing = false;
+        ghost.ServerSetExternalControl(false);
+        if (fleeCo != null) StopCoroutine(fleeCo);
+        fleeCo = null;
+    }
+
+    [Server]
+    IEnumerator FleeLoop()
+    {
+        while (fleeing && !stunned)
+        {
+            Vector3 away = (transform.position - lastOrigin).normalized;
+            Vector3 random = Random.insideUnitSphere; random.y = 0f;
+            float step = Random.Range(fleeStepRange.x, fleeStepRange.y);
+            Vector3 target = transform.position + (away + random).normalized * step;
+            if (Ghost.TryGetRandomPointOnNavmesh(target, fleeRadius, out var dest, agent.areaMask, 2f))
+                agent.SetDestination(dest);
+
+            float exposure01 = Mathf.Clamp01(exposureTimer / Mathf.Max(0.01f, uvSecondsToStun));
+            escapeIntensity = escapeCurve.Evaluate(exposure01);
+            yield return new WaitForSeconds(fleeDecisionInterval);
+        }
+    }
+
+    [Server]
+    void StartStun()
+    {
+        if (stunned) return;
+        stunned = true;
+        fleeing = false;
+        ghost.ServerSetExternalControl(true);
+        if (fleeCo != null) StopCoroutine(fleeCo);
+        fleeCo = null;
+        stunCo = StartCoroutine(StunLoop());
+    }
+
+    [Server]
+    IEnumerator StunLoop()
+    {
+        float end = Time.time + stunSeconds;
+        while (Time.time < end)
+        {
+            float t = 1f - ((end - Time.time) / Mathf.Max(0.01f, stunSeconds));
+            stunIntensity = stunCurve.Evaluate(t);
+            yield return null;
+        }
+        stunned = false;
+        ghost.ServerSetExternalControl(false);
+        stunCo = null;
+        exposureTimer = 0f;
+    }
+
+    void OnFleeState(bool _, bool newVal)
+    {
+        if (newVal) onFleeStart?.Invoke();
+        else onFleeEnd?.Invoke();
+    }
+
+    void OnStunState(bool _, bool newVal)
+    {
+        if (newVal) onStunStart?.Invoke();
+        else onStunEnd?.Invoke();
+    }
+
+    void OnEscapeIntensity(float _, float newVal) => onEscapeIntensity?.Invoke(newVal);
+    void OnStunIntensity(float _, float newVal)   => onStunIntensity?.Invoke(newVal);
+}

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostCaptureable.cs.meta
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostCaptureable.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 2633cf95-37d0-4ec4-a9dd-f511d990dca4
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Enable ghosts to defer navigation when external control (flee/stun) is active
- Introduce GhostCaptureable to handle UV exposure, fleeing, and stun logic
- Add UV raycast reporting in PlayerFlashlight and capture tuning fields in GhostArchetype

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cc5140d48332880cc6f2a7ecdfff