### PR TITLE
Add debug logs for UV interactions

### DIFF
--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostCaptureable.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostCaptureable.cs
@@ -72,6 +72,7 @@ public class GhostCaptureable : NetworkBehaviour
         lastUVTime = now;
         exposureTimer += dt;
         lastOrigin = origin;
+        Debug.Log($"[GhostCaptureable] {name} recebeu UV: {exposureTimer:F2}/{uvSecondsToStun:F2}s");
 
         if (!stunned)
         {
@@ -101,6 +102,7 @@ public class GhostCaptureable : NetworkBehaviour
     {
         if (fleeing || stunned) return;
         fleeing = true;
+        Debug.Log($"[GhostCaptureable] {name} fugindo da UV");
         ghost.ServerSetExternalControl(true);
         fleeCo = StartCoroutine(FleeLoop());
     }
@@ -138,6 +140,7 @@ public class GhostCaptureable : NetworkBehaviour
     {
         if (stunned) return;
         stunned = true;
+        Debug.Log($"[GhostCaptureable] {name} foi atordoado pela UV");
         fleeing = false;
         ghost.ServerSetExternalControl(true);
         if (fleeCo != null) StopCoroutine(fleeCo);
@@ -159,6 +162,7 @@ public class GhostCaptureable : NetworkBehaviour
         ghost.ServerSetExternalControl(false);
         stunCo = null;
         exposureTimer = 0f;
+        Debug.Log($"[GhostCaptureable] {name} recuperou do stun");
     }
 
     void OnFleeState(bool _, bool newVal)

--- a/Assets/_Runtime/Scripts/Player/PlayerFlashlight.cs
+++ b/Assets/_Runtime/Scripts/Player/PlayerFlashlight.cs
@@ -149,6 +149,7 @@ public class PlayerFlashlight : NetworkBehaviour
     [Command]
     void CmdUVHit(uint netId, Vector3 origin, float dt)
     {
+        Debug.Log($"[PlayerFlashlight] Reportando UV no netId {netId}");
         if (NetworkServer.spawned.TryGetValue(netId, out var identity))
         {
             var cap = identity.GetComponent<GhostCaptureable>();
@@ -169,9 +170,11 @@ public class PlayerFlashlight : NetworkBehaviour
         var ray = new Ray(uvRayOrigin.position, uvRayOrigin.forward);
         if (Physics.SphereCast(ray, uvRayRadius, out var hit, uvRayDistance, uvLayerMask, QueryTriggerInteraction.Ignore))
         {
+            Debug.Log($"[PlayerFlashlight] UV apontando para {hit.collider.name}");
             var cap = hit.collider.GetComponentInParent<GhostCaptureable>();
             if (cap)
             {
+                Debug.Log($"[PlayerFlashlight] UV atingiu fantasma {cap.name}");
                 var id = cap.netIdentity;
                 if (id)
                     CmdUVHit(id.netId, uvRayOrigin.position, uvReportInterval);


### PR DESCRIPTION
## Summary
- log object and ghost targeted when UV flashlight is used
- report UV hits to server with detailed netId
- track ghost UV exposure, flee, and stun states with debug messages

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cf2ea5408332823553c9bcafe30e