### PR TITLE
feat: aggressive flee behaviour for ghosts

### DIFF
--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs
@@ -44,4 +44,10 @@ public partial class GhostArchetype : ScriptableObject
     public float capture_fleeRadius = 10f;
     public AnimationCurve capture_escapeCurve = AnimationCurve.EaseInOut(0,0,1,1);
     public AnimationCurve capture_stunCurve   = AnimationCurve.EaseInOut(0,1,1,0);
+
+    [Header("Capture – Aggressive Flee")]
+    public float capture_fleeSpeedMultiplier = 2.2f;
+    public Vector2 capture_fleeSegmentDuration = new Vector2(0.8f, 1.4f); // “corrida” contínua
+    [Range(0,1)] public float capture_hardTurnChance = 0.40f;
+    public Vector2 capture_hardTurnDegrees = new Vector2(60f, 140f); // viradas secas aleatórias
 }


### PR DESCRIPTION
## Summary
- add aggressive flee parameters to `GhostArchetype`
- boost NavMeshAgent settings during UV flee sequences
- replace flee logic with longer segments and unpredictable hard turns

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d93dc9748332b1fdcc749169b15a