### PR TITLE
Send UV direction and lateral ghost flee

### DIFF
--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs
@@ -9,8 +9,8 @@ public partial class GhostArchetype : ScriptableObject
     [Header("Stats")]
     public int maxHP = 100;
     public float moveSpeed = 3.6f;
-    public float acceleration = 30f;
-    public float angularSpeed = 720f;
+    public float acceleration = 40f;
+    public float angularSpeed = 900f;
     public float stoppingDistance = 0.2f;
 
     [Header("Wander")]
@@ -39,9 +39,9 @@ public partial class GhostArchetype : ScriptableObject
     public float capture_uvSecondsToStun = 2.0f;
     public float capture_stunSeconds = 3.0f;
     public float capture_exposureGraceWindow = 0.6f;
-    public float capture_fleeDecisionInterval = 0.25f;
-    public Vector2 capture_fleeStepRange = new Vector2(1.5f, 3.5f);
-    public float capture_fleeRadius = 10f;
+    public float capture_fleeDecisionInterval = 0.5f;
+    public Vector2 capture_fleeStepRange = new Vector2(8f, 15f);
+    public float capture_fleeRadius = 24f;
     public AnimationCurve capture_escapeCurve = AnimationCurve.EaseInOut(0,0,1,1);
     public AnimationCurve capture_stunCurve   = AnimationCurve.EaseInOut(0,1,1,0);
 

--- a/Assets/_Runtime/Scripts/Player/PlayerFlashlight.cs
+++ b/Assets/_Runtime/Scripts/Player/PlayerFlashlight.cs
@@ -150,14 +150,14 @@ public class PlayerFlashlight : NetworkBehaviour
     }
 
     [Command]
-    void CmdUVHit(uint netId, Vector3 origin, float dt)
+    void CmdUVHit(uint netId, Vector3 origin, Vector3 dir, float dt)
     {
         Debug.Log($"[PF][SV] Reportando UV no netId {netId} dt={dt:F2}");
         if (NetworkServer.spawned.TryGetValue(netId, out var identity))
         {
             var cap = identity.GetComponent<GhostCaptureable>();
             if (cap)
-                cap.ServerApplyUVHit(origin, dt);
+                cap.ServerApplyUVHit(origin, dir, dt);
         }
     }
 
@@ -183,7 +183,7 @@ public class PlayerFlashlight : NetworkBehaviour
                 {
                     if (Time.time >= nextUVReportTime)
                     {
-                        CmdUVHit(id.netId, uvRayOrigin.position, uvReportInterval);
+                        CmdUVHit(id.netId, uvRayOrigin.position, uvRayOrigin.forward, uvReportInterval);
                         nextUVReportTime = Time.time + uvReportInterval;
                     }
                 }


### PR DESCRIPTION
## Summary
- Send UV ray direction from PlayerFlashlight to server
- Store UV beam direction in GhostCaptureable and flee laterally from beam axis
- Tune Ghost archetype default flee parameters for sharper movement

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(package not found)*
- `apt-get install -y dotnet-sdk-6.0` *(package not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a8db53ce708332a92695729a5877dd