### PR TITLE
Refactor ghost motion stats and capture system

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -724,54 +724,6 @@ MonoBehaviour:
   fleeDecisionInterval: 0.25
   fleeStepRange: {x: 1.5, y: 3.5}
   fleeRadius: 10
-  escapeCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  stunCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
   onFleeStart:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/_Runtime/Scripts/Enemies/EnemyType/Data/New Ghost Archetype.asset
+++ b/Assets/_Runtime/Scripts/Enemies/EnemyType/Data/New Ghost Archetype.asset
@@ -14,10 +14,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::GhostArchetype
   ghostClass: 0
   maxHP: 100
-  moveSpeed: 3
-  acceleration: 8
-  angularSpeed: 240
-  stoppingDistance: 0.2
+  defaultStats:
+    moveSpeed: 3.6
+    acceleration: 40
+    angularSpeed: 900
+    stoppingDistance: 0.2
+  fleeStats:
+    moveSpeed: 7.5
+    acceleration: 50
+    angularSpeed: 1000
+    stoppingDistance: 0.1
   wanderRadius: 12
   pathRecalcDistance: 0.6
   idlePauseRange: {x: 0.5, y: 1.5}
@@ -37,56 +43,8 @@ MonoBehaviour:
   capture_stunSeconds: 3
   capture_exposureGraceWindow: 0.6
   capture_fleeDecisionInterval: 0.25
-  capture_fleeStepRange: {x: 8, y: 15}
-  capture_fleeRadius: 15
-  capture_escapeCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  capture_stunCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
+  capture_fleeStepRange: {x: 1.5, y: 3.5}
+  capture_fleeRadius: 10
   capture_fleeSpeedMultiplier: 2.2
   capture_fleeSegmentDuration: {x: 0.8, y: 1.4}
   capture_hardTurnChance: 0.4

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/Ghost.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/Ghost.cs
@@ -30,10 +30,11 @@ public class Ghost : NetworkBehaviour
     void ApplyConfig()
     {
         if (!agent || archetype == null) return;
-        agent.speed = archetype.moveSpeed;
-        agent.acceleration = archetype.acceleration;
-        agent.angularSpeed = archetype.angularSpeed;
-        agent.stoppingDistance = archetype.stoppingDistance;
+        var s = archetype.defaultStats;
+        agent.speed = s.moveSpeed;
+        agent.acceleration = s.acceleration;
+        agent.angularSpeed = s.angularSpeed;
+        agent.stoppingDistance = s.stoppingDistance;
         agent.areaMask = archetype.areaMask;
         agent.autoRepath = true;
         agent.obstacleAvoidanceType = ObstacleAvoidanceType.HighQualityObstacleAvoidance;

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype.cs
@@ -6,12 +6,31 @@ public partial class GhostArchetype : ScriptableObject
     public enum Class { Weak, Possessor, Heavy }
     public Class ghostClass = Class.Weak;
 
+    [System.Serializable]
+    public struct MotionStats
+    {
+        public float moveSpeed;
+        public float acceleration;
+        public float angularSpeed;
+        public float stoppingDistance;
+    }
+
     [Header("Stats")]
     public int maxHP = 100;
-    public float moveSpeed = 3.6f;
-    public float acceleration = 40f;
-    public float angularSpeed = 900f;
-    public float stoppingDistance = 0.2f;
+    public MotionStats defaultStats = new MotionStats
+    {
+        moveSpeed = 3.6f,
+        acceleration = 40f,
+        angularSpeed = 900f,
+        stoppingDistance = 0.2f
+    };
+    public MotionStats fleeStats = new MotionStats
+    {
+        moveSpeed = 7.5f,
+        acceleration = 50f,
+        angularSpeed = 1000f,
+        stoppingDistance = 0.1f
+    };
 
     [Header("Wander")]
     public float wanderRadius = 12f;
@@ -39,11 +58,9 @@ public partial class GhostArchetype : ScriptableObject
     public float capture_uvSecondsToStun = 2.0f;
     public float capture_stunSeconds = 3.0f;
     public float capture_exposureGraceWindow = 0.6f;
-    public float capture_fleeDecisionInterval = 0.5f;
-    public Vector2 capture_fleeStepRange = new Vector2(8f, 15f);
-    public float capture_fleeRadius = 24f;
-    public AnimationCurve capture_escapeCurve = AnimationCurve.EaseInOut(0,0,1,1);
-    public AnimationCurve capture_stunCurve   = AnimationCurve.EaseInOut(0,1,1,0);
+    public float capture_fleeDecisionInterval = 0.25f;
+    public Vector2 capture_fleeStepRange = new Vector2(1.5f, 3.5f);
+    public float capture_fleeRadius = 10f;
 
     [Header("Capture – Aggressive Flee")]
     public float capture_fleeSpeedMultiplier = 2.2f;


### PR DESCRIPTION
## Summary
- Split ghost movement stats into `MotionStats` with separate `default` and `flee` profiles
- Replace capture curves with linear intensities and swap to flee stats during UV exposure
- Update assets and scene data to match new stats layout

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a8def3b720833298082947935b4224