### PR TITLE
Add vacuum capture minigame and player controls

### DIFF
--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype_CaptureMinigame.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype_CaptureMinigame.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+public partial class GhostArchetype
+{
+    [Header("Capture – Vacuum/Minigame")]
+    [Tooltip("Tempo contínuo de sucção para capturar (s), ignorando minigames.")]
+    public float capture_vacuumSecondsToCapture = 4.0f;
+
+    [Range(0,3), Tooltip("Qtde de minigames: 0..3. Se 1: gatilho em 33%; 2: 33% e 66%; 3: 33%/66%/99%.")]
+    public int capture_minigameCount = 3;
+
+    [Tooltip("Velocidade do handle do minigame (u/s, 0..1 por segundo). Valores mais altos = mais difícil.")]
+    public float capture_minigameHandleSpeed = 1.75f;
+
+    [Range(0.01f, 0.20f), Tooltip("Janela de acerto (+/-) em fração da barra (ex.: 0.06 = ±6%)")]
+    public float capture_minigameHitWindow = 0.06f;
+}
+

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype_CaptureMinigame.cs.meta
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype_CaptureMinigame.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2764cd0b87a146ad85550f456163b62f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostCaptureable.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostCaptureable.cs
@@ -211,4 +211,30 @@ public class GhostCaptureable : NetworkBehaviour
 
     void OnEscapeIntensity(float _, float newVal) => onEscapeIntensity?.Invoke(newVal);
     void OnStunIntensity(float _, float newVal)   => onStunIntensity?.Invoke(newVal);
+
+    // ====== ADIÇÕES SIMPLES (colar dentro de GhostCaptureable) ======
+
+    // Getters simples para outras classes
+    [Server] public bool IsStunned() => stunned;
+    public GhostArchetype GetArchetype() => archetype;
+
+    // Força sair do stun IMEDIATAMENTE, mantendo o fantasma travado.
+    // Útil quando começa a sucção: "zera o stun, mas mantenha parado".
+    [Server]
+    public void ServerForceExitStunKeepFrozen()
+    {
+        if (!stunned) return;
+
+        if (stunCo != null)
+        {
+            StopCoroutine(stunCo);
+            stunCo = null;
+        }
+
+        stunned = false;                       // dispara hook onStunEnd nos clientes
+        ghost.ServerSetExternalControl(true);  // permanece parado
+        if (archetype) ApplyMotionStats(archetype.defaultStats, false);
+        // zera acúmulo de exposição
+        exposureTimer = 0f;
+    }
 }

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostVacuum.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostVacuum.cs
@@ -1,0 +1,214 @@
+using System.Collections.Generic;
+using Mirror;
+using UnityEngine;
+using UnityEngine.AI;
+
+/// <summary>
+/// Lógica servidor da captura por Vacuum (progresso, travamento do fantasma, minigames).
+/// Requer GhostCaptureable (para stun/flee) e Ghost (para externalControl).
+/// </summary>
+[RequireComponent(typeof(GhostCaptureable))]
+[RequireComponent(typeof(Ghost))]
+[RequireComponent(typeof(NavMeshAgent))]
+public class GhostVacuum : NetworkBehaviour
+{
+    [Header("Config (override opcional; se 0, lê do Archetype)")]
+    public float secondsToCapture = 0f;     // 0 = pega do archetype
+    [Range(0,3)] public int minigameCount = -1; // -1 = pega do archetype
+    public float minigameHandleSpeed = 0f;  // 0 = archetype
+    [Range(0.01f,0.2f)] public float minigameHitWindow = 0f; // 0 = archetype
+
+    [Header("Eventos/UI (opcional)")]
+    public UnityEngine.Events.UnityEvent<float> onProgress; // 0..1
+
+    // ---- Estado replicado
+    [SyncVar(hook = nameof(OnCapturingChanged))] private bool capturing;
+    [SyncVar(hook = nameof(OnProgressChanged))]  private float progress01; // 0..1
+    [SyncVar] private int awaitingStage; // 0=nenhum; 1..3 = aguardando minigame
+    [SyncVar] private uint capturingPlayerNetId;
+
+    // ---- refs
+    private GhostCaptureable cap;
+    private Ghost ghost;
+    private NavMeshAgent agent;
+    private GhostArchetype arch;
+
+    // ---- auxiliares servidor
+    private float[] stageThresholds = new float[] { 0.33f, 0.66f, 0.99f };
+
+    public override void OnStartServer()
+    {
+        cap   = GetComponent<GhostCaptureable>();
+        ghost = GetComponent<Ghost>();
+        agent = GetComponent<NavMeshAgent>();
+
+        arch = GetArchetypeSafely();
+        if (arch)
+        {
+            if (secondsToCapture <= 0f) secondsToCapture = Mathf.Max(0.1f, arch.capture_vacuumSecondsToCapture);
+            if (minigameCount    <  0)  minigameCount    = Mathf.Clamp(arch.capture_minigameCount, 0, 3);
+            if (minigameHandleSpeed <= 0f) minigameHandleSpeed = Mathf.Max(0.1f, arch.capture_minigameHandleSpeed);
+            if (minigameHitWindow    <= 0f) minigameHitWindow    = Mathf.Clamp(arch.capture_minigameHitWindow, 0.01f, 0.20f);
+        }
+        else
+        {
+            if (secondsToCapture <= 0f) secondsToCapture = 4f;
+            if (minigameCount    <  0)  minigameCount    = 3;
+            if (minigameHandleSpeed <= 0f) minigameHandleSpeed = 1.75f;
+            if (minigameHitWindow    <= 0f) minigameHitWindow = 0.06f;
+        }
+    }
+
+    GhostArchetype GetArchetypeSafely()
+    {
+        // GhostCaptureable e Ghost possuem referência de archetype no seu serialized
+        // Aqui opto por acessar via campo privado por SerializeField; se não existir, retorna null.
+        var f = typeof(GhostCaptureable).GetField("archetype", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        return f != null ? (GhostArchetype)f.GetValue(cap) : null;
+    }
+
+    // ============== API (servidor) chamada pelo PlayerVacuum ==============
+
+    [Server]
+    public void ServerApplyVacuumHit(uint playerNetId, Vector3 origin, Vector3 dir, float dt)
+    {
+        if (!cap || !ghost) return;
+
+        // Começa somente se estava stunnado
+        if (!capturing)
+        {
+            if (!cap.IsStunned()) return;                // precisa estar stunnado
+            StartCapturing(playerNetId);                 // 1. Ao começar a sugar...
+            cap.ServerForceExitStunKeepFrozen();         // 1.5 zera o stun, porém mantém parado
+        }
+
+        // Uma vez capturando, trava o "dono"
+        if (capturingPlayerNetId != playerNetId) return;
+
+        // Enquanto houver minigame pendente, não avança a barra
+        if (awaitingStage > 0) return;
+
+        // Avança progresso
+        progress01 = Mathf.Clamp01(progress01 + (dt / Mathf.Max(0.01f, secondsToCapture)));
+
+        // Gatilhos dos minigames
+        TriggerMinigamesIfNeeded();
+
+        // Captura completa
+        if (progress01 >= 1f && awaitingStage == 0)
+        {
+            CompleteCapture();
+        }
+    }
+
+    [Server]
+    public void ServerResolveMinigameResult(uint playerNetId, int stageIndex, bool success)
+    {
+        if (!capturing || awaitingStage == 0) return;
+        if (playerNetId != capturingPlayerNetId) return;
+        if (stageIndex != awaitingStage) return;
+
+        if (!success)
+        {
+            // Falha: cancela tudo, fantasma volta "ao normal" (sem stun, andando)
+            FailAndRelease();
+            return;
+        }
+
+        // Sucesso: limpa o "await" e segue sugando
+        awaitingStage = 0;
+    }
+
+    // ============== Internals ==============
+
+    [Server]
+    void StartCapturing(uint playerNetId)
+    {
+        capturing = true;
+        capturingPlayerNetId = playerNetId;
+
+        // congela movimento e zera velocidade instantaneamente
+        ghost.ServerSetExternalControl(true);
+        agent.ResetPath();
+        agent.velocity = Vector3.zero;
+    }
+
+    [Server]
+    void TriggerMinigamesIfNeeded()
+    {
+        if (minigameCount <= 0) return;
+
+        // Checa thresholds na ordem; dispara o próximo ainda não cumprido
+        for (int i = 1; i <= minigameCount; i++)
+        {
+            if (awaitingStage != 0) break; // já aguardando
+            float thr = stageThresholds[i - 1];
+            // Dispara quando cruzar o threshold (>=), sem repetir
+            if (progress01 >= thr)
+            {
+                awaitingStage = i;
+                BeginMinigame(i);
+            }
+        }
+    }
+
+    [Server]
+    void BeginMinigame(int stageIndex)
+    {
+        // parâmetros
+        float speed   = minigameHandleSpeed;
+        float marker  = Random.Range(0.15f, 0.85f);
+        float window  = minigameHitWindow;
+
+        if (!NetworkServer.spawned.TryGetValue(capturingPlayerNetId, out var playerId) || playerId.connectionToClient == null)
+        {
+            // jogador sumiu? falha dura
+            FailAndRelease();
+            return;
+        }
+
+        TargetBeginMinigame(playerId.connectionToClient, netIdentity.netId, stageIndex, speed, marker, window);
+    }
+
+    [TargetRpc]
+    void TargetBeginMinigame(NetworkConnectionToClient conn, uint ghostNetId, int stageIndex, float speed, float markerPos01, float hitWindow01)
+    {
+        // Cliente: dispara UI pelo PlayerVacuum local
+        if (PlayerVacuum.Local)
+            PlayerVacuum.Local.ClientStartMinigame(ghostNetId, stageIndex, speed, markerPos01, hitWindow01);
+    }
+
+    [Server]
+    void CompleteCapture()
+    {
+        capturing = false;
+        awaitingStage = 0;
+
+        // Aqui você pode tocar VFX/SFX, soltar loot etc.
+        NetworkServer.Destroy(gameObject); // remove o fantasma capturado
+    }
+
+    [Server]
+    void FailAndRelease()
+    {
+        capturing = false;
+        awaitingStage = 0;
+        progress01 = 0f;
+        capturingPlayerNetId = 0;
+
+        // Libera controle para IA voltar a andar
+        ghost.ServerSetExternalControl(false);
+    }
+
+    // ============== Hooks replicação (UI local etc.) ==============
+
+    void OnCapturingChanged(bool _, bool now)
+    {
+        // placeholder; você pode ligar/desligar VFX de "sucção"
+    }
+    void OnProgressChanged(float _, float now)
+    {
+        onProgress?.Invoke(now);
+    }
+}
+

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostVacuum.cs.meta
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostVacuum.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c137ab3dcdf24a75bc937da08a16ea56
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Assets/_Runtime/Scripts/Player/PlayerVacuum.cs
+++ b/Assets/_Runtime/Scripts/Player/PlayerVacuum.cs
@@ -1,0 +1,156 @@
+using Mirror;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// Raycast de Vacuum do jogador: segura botão p/ sugar; reporta ao servidor em ticks (dt).
+/// Também encaminha o resultado do minigame ao servidor.
+/// NÃO depende do InputSystem_Actions gerado: use InputActionReference no Inspector.
+/// </summary>
+[DisallowMultipleComponent]
+public class PlayerVacuum : NetworkBehaviour
+{
+    [Header("Raycast")]
+    public Transform vacuumRayOrigin;
+    public float vacuumRayDistance = 10f;
+    public float vacuumRayRadius = 0.5f;
+    public LayerMask vacuumLayerMask = ~0;
+    public float reportInterval = 0.1f;
+
+    [Header("Inputs (Input System)")]
+    [Tooltip("Ação de segurar o Vacuum (ex.: LMB). Type=Button, Interaction=Press&Hold")]
+    public InputActionReference holdVacuumAction;
+    [Tooltip("Ação de Interact usada para 'bater' no minigame (ex.: E)")]
+    public InputActionReference interactAction;
+
+    // ---- runtime local
+    private bool holdingVacuum;
+    private float nextReportTime;
+    private Camera _cam;
+
+    // ---- minigame UI no cliente
+    public static PlayerVacuum Local; // singleton local
+    private CaptureMinigameUI currentUI;
+
+    public override void OnStartLocalPlayer()
+    {
+        Local = this;
+
+        if (holdVacuumAction && holdVacuumAction.action != null)
+        {
+            holdVacuumAction.action.performed += OnHoldPerformed;
+            holdVacuumAction.action.canceled  += OnHoldCanceled;
+            holdVacuumAction.action.Enable();
+        }
+
+        if (interactAction && interactAction.action != null)
+        {
+            interactAction.action.performed += OnInteract;
+            interactAction.action.Enable();
+        }
+
+        _cam = Camera.main;
+    }
+
+    private void OnDisable()
+    {
+        if (isLocalPlayer)
+        {
+            if (holdVacuumAction && holdVacuumAction.action != null)
+            {
+                holdVacuumAction.action.performed -= OnHoldPerformed;
+                holdVacuumAction.action.canceled  -= OnHoldCanceled;
+            }
+            if (interactAction && interactAction.action != null)
+            {
+                interactAction.action.performed -= OnInteract;
+            }
+        }
+    }
+
+    void OnHoldPerformed(InputAction.CallbackContext _)
+    {
+        if (!isLocalPlayer) return;
+        holdingVacuum = true;
+    }
+
+    void OnHoldCanceled(InputAction.CallbackContext _)
+    {
+        if (!isLocalPlayer) return;
+        holdingVacuum = false;
+    }
+
+    void OnInteract(InputAction.CallbackContext _)
+    {
+        if (!isLocalPlayer) return;
+        // Encaminha o "golpe" ao UI, se houver
+        if (currentUI && currentUI.isActiveAndEnabled)
+            currentUI.Strike();
+    }
+
+    void Update()
+    {
+        if (!isLocalPlayer) return;
+        if (!holdingVacuum) return;
+        if (!vacuumRayOrigin) return;
+
+        // Ray visual
+        var ray = new Ray(vacuumRayOrigin.position, vacuumRayOrigin.forward);
+        Debug.DrawRay(ray.origin, ray.direction * vacuumRayDistance, Color.cyan);
+
+        if (Time.time < nextReportTime) return;
+        nextReportTime = Time.time + reportInterval;
+
+        if (Physics.SphereCast(ray, vacuumRayRadius, out var hit, vacuumRayDistance, vacuumLayerMask, QueryTriggerInteraction.Collide))
+        {
+            var cap = hit.collider.GetComponentInParent<GhostCaptureable>();
+            if (cap && cap.netIdentity)
+            {
+                // Reporta tick de sucção
+                CmdVacuumHit(cap.netIdentity.netId, vacuumRayOrigin.position, vacuumRayOrigin.forward, reportInterval);
+            }
+        }
+    }
+
+    // ---------- RPC/Commands ----------
+
+    [Command(requiresAuthority = false)]
+    void CmdVacuumHit(uint ghostNetId, Vector3 origin, Vector3 dir, float dt, NetworkConnectionToClient sender = null)
+    {
+        if (!NetworkServer.spawned.TryGetValue(ghostNetId, out var id)) return;
+        var vac = id.GetComponent<GhostVacuum>();
+        if (!vac) return;
+
+        // netId do jogador que está sugando
+        uint playerNetId = sender != null && sender.identity ? sender.identity.netId : netIdentity.netId;
+        vac.ServerApplyVacuumHit(playerNetId, origin, dir, dt);
+    }
+
+    [Command(requiresAuthority = false)]
+    void CmdMinigameResult(uint ghostNetId, int stageIndex, bool success, NetworkConnectionToClient sender = null)
+    {
+        if (!NetworkServer.spawned.TryGetValue(ghostNetId, out var id)) return;
+        var vac = id.GetComponent<GhostVacuum>();
+        if (!vac) return;
+
+        uint playerNetId = sender != null && sender.identity ? sender.identity.netId : netIdentity.netId;
+        vac.ServerResolveMinigameResult(playerNetId, stageIndex, success);
+    }
+
+    // ---------- Cliente: iniciar minigame (chamado pelo TargetRpc do servidor) ----------
+
+    public void ClientStartMinigame(uint ghostNetId, int stageIndex, float speed, float markerPos01, float hitWindow01)
+    {
+        if (!isLocalPlayer) return;
+
+        if (!currentUI)
+            currentUI = CaptureMinigameUI.Spawn(this);
+
+        currentUI.Begin(ghostNetId, stageIndex, speed, markerPos01, hitWindow01,
+            onFinish: (ok) => {
+                // Reporta ao servidor
+                CmdMinigameResult(ghostNetId, stageIndex, ok);
+            });
+    }
+}
+

--- a/Assets/_Runtime/Scripts/Player/PlayerVacuum.cs.meta
+++ b/Assets/_Runtime/Scripts/Player/PlayerVacuum.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2d0fb42b70644f1491209759fef5a311
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Assets/_Runtime/Scripts/UI/CaptureMinigameUI.cs
+++ b/Assets/_Runtime/Scripts/UI/CaptureMinigameUI.cs
@@ -1,0 +1,107 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// UI extremamente simples com OnGUI para o minigame:
+/// - Barra [0..1]
+/// - Handle que corre da esquerda p/ direita com velocidade configurável
+/// - Marker fixo; jogador deve "bater" (Strike) próximo o suficiente
+/// Integração:
+///   PlayerVacuum chama Begin(...) e depois usa Interact para chamar Strike().
+/// </summary>
+public class CaptureMinigameUI : MonoBehaviour
+{
+    private uint ghostNetId;
+    private int stageIndex;
+    private float speed;
+    private float marker;
+    private float window;
+
+    private float handle; // 0..1
+    private Action<bool> onFinish;
+    private bool active;
+
+    private Rect rect;
+    private const float W = 420f;
+    private const float H = 96f;
+
+    public static CaptureMinigameUI Spawn(PlayerVacuum owner)
+    {
+        var go = new GameObject("CaptureMinigameUI");
+        var ui = go.AddComponent<CaptureMinigameUI>();
+        DontDestroyOnLoad(go);
+        return ui;
+    }
+
+    public void Begin(uint ghostNetId, int stageIndex, float speed, float markerPos01, float hitWindow01, Action<bool> onFinish)
+    {
+        this.ghostNetId = ghostNetId;
+        this.stageIndex = stageIndex;
+        this.speed      = Mathf.Max(0.05f, speed);
+        this.marker     = Mathf.Clamp01(markerPos01);
+        this.window     = Mathf.Clamp(hitWindow01, 0.01f, 0.25f);
+        this.onFinish   = onFinish;
+
+        this.handle = 0f;
+        this.active = true;
+
+        var sw = Screen.width; var sh = Screen.height;
+        rect = new Rect((sw - W)/2f, sh*0.75f - H/2f, W, H); // parte baixa da tela
+    }
+
+    public void Strike()
+    {
+        if (!active) return;
+        bool ok = Mathf.Abs(handle - marker) <= window;
+        Finish(ok);
+    }
+
+    void Finish(bool ok)
+    {
+        active = false;
+        onFinish?.Invoke(ok);
+    }
+
+    void Update()
+    {
+        if (!active) return;
+        handle += speed * Time.deltaTime;
+        if (handle >= 1f) handle -= 1f; // volta ao início
+    }
+
+    void OnGUI()
+    {
+        if (!active) return;
+
+        GUI.depth = 0;
+        GUI.Box(rect, GUIContent.none);
+
+        // margem interna
+        var inner = new Rect(rect.x + 12, rect.y + 24, rect.width - 24, 18);
+
+        // fundo
+        GUI.Box(inner, GUIContent.none);
+
+        // marker
+        float mx = inner.x + inner.width * marker;
+        var markRect = new Rect(mx - 2, inner.y - 6, 4, inner.height + 12);
+        GUI.Box(markRect, GUIContent.none);
+
+        // janela de acerto (visual)
+        float wx = inner.width * window;
+        var winRect = new Rect(mx - wx, inner.y, wx*2f, inner.height);
+        Color prev = GUI.color; GUI.color = new Color(0f,1f,0f,0.25f);
+        GUI.DrawTexture(winRect, Texture2D.whiteTexture);
+        GUI.color = prev;
+
+        // handle
+        float hx = inner.x + inner.width * handle;
+        var hRect = new Rect(hx - 6, inner.y - 4, 12, inner.height + 8);
+        GUI.Box(hRect, GUIContent.none);
+
+        // texto
+        var tRect = new Rect(rect.x, rect.y + 54, rect.width, 24);
+        GUI.Label(tRect, $"Stage {stageIndex} • Pressione Interact no alvo");
+    }
+}
+

--- a/Assets/_Runtime/Scripts/UI/CaptureMinigameUI.cs.meta
+++ b/Assets/_Runtime/Scripts/UI/CaptureMinigameUI.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 17f9f5a0270447198ac55821562b4bd1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+


### PR DESCRIPTION
## Summary
- add archetype settings for vacuum capture and minigame tuning
- implement player vacuum raycast and networking commands
- add ghost-side capture logic with minigame triggers and simple UI

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e3d100f0833281ad432e1d30b73a