### PR TITLE
Add minigame checkpoints to ghost capture

### DIFF
--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype_CaptureMinigame.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype_CaptureMinigame.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public partial class GhostArchetype
+{
+    [Header("Capture – Minigame (Marker/Window)")]
+    [Range(1,3)] public int mg_rounds = 3;        // quantos checkpoints (ex.: 1..3)
+    [Tooltip("Velocidade do marker por round (0..1 normalizado por segundo, ping-pong).")]
+    public float[] mg_markerSpeed = new float[] { 1.2f, 1.6f, 2.0f };
+    [Tooltip("Largura da janela de acerto por round (0..1).")]
+    public float[] mg_windowWidth = new float[] { 0.22f, 0.18f, 0.14f };
+    [Tooltip("Quantas tentativas dentro do mesmo round (ex.: 1,1,2).")]
+    public int[] mg_attempts = new int[] { 1, 1, 1 };
+    [Tooltip("Penalidade ao falhar (fração do progresso 0..1 removida).")]
+    [Range(0f, 0.5f)] public float mg_failPenalty = 0.12f;
+}
+

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype_CaptureMinigame.cs.meta
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype_CaptureMinigame.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f00fa0b0521e48fc8d8937af81e8f093
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Runtime/Scripts/Player/PlayerMinigameBridge.cs
+++ b/Assets/_Runtime/Scripts/Player/PlayerMinigameBridge.cs
@@ -1,0 +1,52 @@
+using Mirror;
+using UnityEngine;
+
+public class PlayerMinigameBridge : NetworkBehaviour
+{
+    [Header("Refs")]
+    public MinigameMarkerWindow ui;
+
+    // Runtime
+    private uint currentGhostNetId;
+
+    public override void OnStartLocalPlayer()
+    {
+        base.OnStartLocalPlayer();
+        if (ui) ui.StopMinigame();
+    }
+
+    // ===== chamado pelo servidor para este cliente específico =====
+    [TargetRpc]
+    public void Target_StartMinigame(NetworkConnectionToClient _, uint ghostNetId, float speed, float width, int attempts, int requiredSuccesses)
+    {
+        if (!isLocalPlayer || ui == null) return;
+        currentGhostNetId = ghostNetId;
+
+        ui.onAllSuccess.RemoveAllListeners();
+        ui.onAllFail.RemoveAllListeners();
+
+        ui.onAllSuccess.AddListener(() => Cmd_ReportMinigameResult(currentGhostNetId, true));
+        ui.onAllFail.AddListener(() => Cmd_ReportMinigameResult(currentGhostNetId, false));
+
+        ui.StartMinigame(new MinigameMarkerWindow.Params {
+            markerSpeed = speed,
+            windowWidth = width,
+            attempts = attempts,
+            requiredSuccesses = requiredSuccesses
+        });
+    }
+
+    [Command]
+    void Cmd_ReportMinigameResult(uint ghostNetId, bool success)
+    {
+        // Encaminha para o GhostVacuum correto no servidor
+        if (!NetworkServer.spawned.TryGetValue(ghostNetId, out var id)) return;
+        var gv = id.GetComponent<GhostVacuum>();
+        if (!gv) return;
+
+        // Confirma autoria: este Command vem do jogador correto?
+        var senderNetId = connectionToClient?.identity ? connectionToClient.identity.netId : netIdentity.netId;
+        gv.ServerOnMinigameResult(senderNetId, success);
+    }
+}
+

--- a/Assets/_Runtime/Scripts/Player/PlayerMinigameBridge.cs.meta
+++ b/Assets/_Runtime/Scripts/Player/PlayerMinigameBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88f1cb9aa30a4392a9f5ca6d4884fdf9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Runtime/Scripts/UI/Widgets/MinigameMarkerWindow.cs
+++ b/Assets/_Runtime/Scripts/UI/Widgets/MinigameMarkerWindow.cs
@@ -1,0 +1,144 @@
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.InputSystem;
+
+public class MinigameMarkerWindow : MonoBehaviour
+{
+    [Header("Refs")]
+    [Tooltip("Root para ligar/desligar a UI do minigame.")]
+    public GameObject root;
+    [Tooltip("0..1 no eixo X: posição atual do marker.")]
+    public RectTransform marker;   // anchor/pivot central
+    [Tooltip("0..1 faixa de acerto (janela).")]
+    public RectTransform window;   // dimensionado em runtime
+
+    [Header("Input")]
+    public InputActionReference interactAction; // mesmo botão 'Interact'
+
+    [Header("Callbacks")]
+    public UnityEvent onRoundStart;
+    public UnityEvent onRoundSuccess;
+    public UnityEvent onRoundFail;
+    public UnityEvent onAllSuccess;
+    public UnityEvent onAllFail;
+
+    // runtime
+    private bool active;
+    private float speed;      // unidades normalizadas por segundo
+    private float winCenter;  // 0..1
+    private float winWidth;   // 0..1
+    private int targetAttempts;
+    private int attemptsDone;
+    private int successes;
+    private int successesNeeded;
+
+    private float x;          // 0..1, posição marker
+    private int dir = +1;     // +1 indo pra direita, -1 pra esquerda
+
+    void OnEnable()
+    {
+        if (interactAction && interactAction.action != null)
+        {
+            interactAction.action.performed += OnInteract;
+            interactAction.action.Enable();
+        }
+    }
+    void OnDisable()
+    {
+        if (interactAction && interactAction.action != null)
+            interactAction.action.performed -= OnInteract;
+    }
+
+    public struct Params
+    {
+        public float markerSpeed;
+        public float windowWidth;
+        public int attempts;
+        public int requiredSuccesses; // ex.: 1 (acertou = passou)
+    }
+
+    public void StartMinigame(Params p)
+    {
+        speed = Mathf.Max(0.01f, p.markerSpeed);
+        winWidth = Mathf.Clamp01(p.windowWidth);
+        targetAttempts = Mathf.Max(1, p.attempts);
+        successesNeeded = Mathf.Max(1, p.requiredSuccesses);
+
+        attemptsDone = 0;
+        successes = 0;
+        x = 0f;
+        dir = +1;
+        winCenter = 0.5f; // pode randomizar se quiser
+
+        active = true;
+        if (root) root.SetActive(true);
+        LayoutWindow();
+        onRoundStart?.Invoke();
+    }
+
+    public void StopMinigame()
+    {
+        active = false;
+        if (root) root.SetActive(false);
+    }
+
+    void Update()
+    {
+        if (!active) return;
+
+        // Move o marker ping-pong entre 0..1
+        x += dir * speed * Time.deltaTime;
+        if (x >= 1f) { x = 1f; dir = -1; }
+        if (x <= 0f) { x = 0f; dir = +1; }
+
+        if (marker)
+        {
+            var a = marker.anchorMin; var b = marker.anchorMax;
+            a.x = b.x = x;
+            marker.anchorMin = a; marker.anchorMax = b;
+        }
+    }
+
+    void LayoutWindow()
+    {
+        if (!window) return;
+        float half = winWidth * 0.5f;
+        float min = Mathf.Clamp01(winCenter - half);
+        float max = Mathf.Clamp01(winCenter + half);
+        var a = window.anchorMin; var b = window.anchorMax;
+        a.x = min; b.x = max;
+        window.anchorMin = a; window.anchorMax = b;
+    }
+
+    void OnInteract(InputAction.CallbackContext _)
+    {
+        if (!active) return;
+
+        attemptsDone++;
+        bool hit = Mathf.Abs(x - winCenter) <= (winWidth * 0.5f);
+
+        if (hit)
+        {
+            successes++;
+            onRoundSuccess?.Invoke();
+            if (successes >= successesNeeded)
+            {
+                onAllSuccess?.Invoke();
+                StopMinigame();
+                return;
+            }
+        }
+        else
+        {
+            onRoundFail?.Invoke();
+        }
+
+        if (attemptsDone >= targetAttempts)
+        {
+            // encerrou sem atingir requiredSuccesses
+            onAllFail?.Invoke();
+            StopMinigame();
+        }
+    }
+}
+

--- a/Assets/_Runtime/Scripts/UI/Widgets/MinigameMarkerWindow.cs.meta
+++ b/Assets/_Runtime/Scripts/UI/Widgets/MinigameMarkerWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef4137e8d3994af1acc063de007f2fb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add minigame tuning fields to `GhostArchetype`
- implement local marker-window minigame UI
- add player bridge and extend `GhostVacuum` with server-side checkpoints

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f82f220c833283e58b2761cfd6eb