### PR TITLE
Remove minigame penalty and release ghost on failed round

### DIFF
--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype_CaptureMinigame.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostArchetype_CaptureMinigame.cs
@@ -10,7 +10,5 @@ public partial class GhostArchetype
     public float[] mg_windowWidth = new float[] { 0.22f, 0.18f, 0.14f };
     [Tooltip("Quantas tentativas dentro do mesmo round (ex.: 1,1,2).")]
     public int[] mg_attempts = new int[] { 1, 1, 1 };
-    [Tooltip("Penalidade ao falhar (fração do progresso 0..1 removida).")]
-    [Range(0f, 0.5f)] public float mg_failPenalty = 0.12f;
 }
 


### PR DESCRIPTION
## Summary
- Remove fail penalty settings from ghost minigame archetype
- Release ghost and stop capture when minigame attempt fails

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68a8fc0d89348332b81a2a8555ec53ed