### PR TITLE
Reset capture state on minigame failure

### DIFF
--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostVacuum.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostVacuum.cs
@@ -199,6 +199,8 @@ public class GhostVacuum : NetworkBehaviour
 
         if (!success)
         {
+            progress01 = 0f;
+            nextRoundIndex = 0;
             waitingMinigame = false;
             capturing = false;
             capturingPlayerNetId = 0;


### PR DESCRIPTION
## Summary
- reset capture progress and round index when minigame fails to prevent instant retriggers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fea94c8883328a8957b8dd45ad91