### PR TITLE
Fix ghost flee speed inconsistencies

### DIFF
--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/Ghost.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/Ghost.cs
@@ -121,7 +121,8 @@ public class Ghost : NetworkBehaviour
                     if (externalControl) break;
                     yield return null;
                 }
-                agent.speed = prev;
+                if (!externalControl)
+                    agent.speed = prev;
             }
 
             // Janela curta entre decisões (mais “nervoso”)

--- a/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostCaptureable.cs
+++ b/Assets/_Runtime/Scripts/Enemies/Ghosts/GhostCaptureable.cs
@@ -73,6 +73,8 @@ public class GhostCaptureable : NetworkBehaviour
         agent.obstacleAvoidanceType = flee
             ? ObstacleAvoidanceType.GoodQualityObstacleAvoidance
             : ObstacleAvoidanceType.HighQualityObstacleAvoidance;
+        if (flee && archetype)
+            agent.speed *= archetype.capture_fleeSpeedMultiplier;
     }
 
     [Server]
@@ -114,6 +116,7 @@ public class GhostCaptureable : NetworkBehaviour
         fleeing = true;
         ghost.ServerSetExternalControl(true);
         if (archetype) ApplyMotionStats(archetype.fleeStats, true);
+        Debug.Log($"[GhostCaptureable] {name} entrou em Flee com velocidade {agent.speed:F2}");
         fleeCo = StartCoroutine(FleeLoop());
     }
 


### PR DESCRIPTION
## Summary
- avoid restoring burst speed when external control takes over
- apply aggressive flee speed multiplier and log flee speed

## Testing
- `dotnet build` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a91ed67f6c8332b1fd2b889dc7bf7d